### PR TITLE
Avoid SEGV when destroying QCoreApplication.

### DIFF
--- a/QtSignalForwarder.h
+++ b/QtSignalForwarder.h
@@ -55,6 +55,8 @@ class QtSignalForwarder : public QObject
 
 		QtSignalForwarder(QObject* parent = 0);
 
+		virtual ~QtSignalForwarder();
+
 		/** Set up a binding so that @p callback is invoked when
 		 * @p sender emits @p signal.  If @p signal has default arguments,
 		 * they must be specified.  eg. Use SLOT(clicked(bool)) for a button
@@ -224,6 +226,8 @@ class QtSignalForwarder : public QObject
 		// bindings to QObject::destroy(QObject*) used to detect when a bound
 		// sender is destroyed
 		static QtMetacallAdapter s_senderDestroyedCallback;
+
+		static QList<QtSignalForwarder*> s_sharedProxies;
 };
 
 Q_DECLARE_METATYPE(QtSignalForwarder*)


### PR DESCRIPTION
Remove shared proxies from the static list when they die, so that next
QtSignalForwarder::connect() call does not try to reuse destroyed
object. Instead, it will just create a new one.

This can happen if you create/destroy multiple QCoreApplication objects,
e.g. in tests.
