### PR TITLE
Add support for non-application threads

### DIFF
--- a/QtSignalForwarder.cpp
+++ b/QtSignalForwarder.cpp
@@ -255,7 +255,7 @@ QtSignalForwarder* QtSignalForwarder::sharedProxy(QObject* sender)
 	//
 	static QList<QtSignalForwarder*> proxies;
 	if (proxies.isEmpty() || !proxies.last()->canAddSignalBindings()) {
-		QtSignalForwarder* newProxy = new QtSignalForwarder(QCoreApplication::instance());
+		QtSignalForwarder* newProxy = new QtSignalForwarder();
 		proxies << newProxy;
 	}
 	return proxies.last();

--- a/QtSignalForwarder.h
+++ b/QtSignalForwarder.h
@@ -55,8 +55,6 @@ class QtSignalForwarder : public QObject
 
 		QtSignalForwarder(QObject* parent = 0);
 
-		virtual ~QtSignalForwarder();
-
 		/** Set up a binding so that @p callback is invoked when
 		 * @p sender emits @p signal.  If @p signal has default arguments,
 		 * they must be specified.  eg. Use SLOT(clicked(bool)) for a button
@@ -226,8 +224,6 @@ class QtSignalForwarder : public QObject
 		// bindings to QObject::destroy(QObject*) used to detect when a bound
 		// sender is destroyed
 		static QtMetacallAdapter s_senderDestroyedCallback;
-
-		static QList<QtSignalForwarder*> s_sharedProxies;
 };
 
 Q_DECLARE_METATYPE(QtSignalForwarder*)

--- a/QtSignalForwarder.h
+++ b/QtSignalForwarder.h
@@ -54,6 +54,7 @@ class QtSignalForwarder : public QObject
 		typedef bool (*EventFilterFunc)(QObject*,QEvent*);
 
 		QtSignalForwarder(QObject* parent = 0);
+		virtual ~QtSignalForwarder();
 
 		/** Set up a binding so that @p callback is invoked when
 		 * @p sender emits @p signal.  If @p signal has default arguments,

--- a/tests/TestQtSignalTools.h
+++ b/tests/TestQtSignalTools.h
@@ -29,6 +29,7 @@ class TestQtSignalTools : public QObject
 		void testContextDestroyed();
 		void testContextDestroyedEqualsSender();
 		void testContextDestroyedShared();
+		void testThread();
 
 		void testConnectPerf();
 };


### PR DESCRIPTION
I reverted recent commit and I fix the crash when application finishes by not setting parent to the proxies.
I don't think it is worth to set parent to QCoreApplication just in the application thread. 
